### PR TITLE
Fix invalid_base64_test

### DIFF
--- a/src/hairnet.erl
+++ b/src/hairnet.erl
@@ -139,7 +139,7 @@ decode_token(EncodedToken) ->
     try
         base64url:decode(EncodedToken)
     catch
-        error:{badarg, _Char} -> throw(invalid_base64)
+        error:badarg -> throw(invalid_base64)
     end.
 
 %%-------------------------------------------------------------------


### PR DESCRIPTION
Erlang throws `error:badarg` not `error:{badarg, _Char}`